### PR TITLE
Change blocks1 to use bash instead of /bin/sh

### DIFF
--- a/color-scripts/blocks1
+++ b/color-scripts/blocks1
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 pcs() { for i in {0..7}; do echo -en "\e[${1}$((30+$i))m \u2588\u2588 \e[0m"; done; }
 printf "\n%s\n%s\n\n" "$(pcs)" "$(pcs '1;')"

--- a/color-scripts/blocks1
+++ b/color-scripts/blocks1
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 pcs() { for i in {0..7}; do echo -en "\e[${1}$((30+$i))m \u2588\u2588 \e[0m"; done; }
 printf "\n%s\n%s\n\n" "$(pcs)" "$(pcs '1;')"


### PR DESCRIPTION
It doesn't work if /bin/sh isn't a link to bash anyway. On Debian-based systems the script fails with `./blocks1: 2: ./blocks1: arithmetic expression: expecting primary: "30+{0..7}"`. Changing the shell to bash makes everything seem to work okay.