### PR TITLE
Pipes2 requires bash as shell

### DIFF
--- a/color-scripts/pipes2
+++ b/color-scripts/pipes2
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 declare -i f=75 s=13 r=2000 t=0 c=1 n=0 l=0
 declare -ir w=$(tput cols) h=$(tput lines)


### PR DESCRIPTION
The pipes2 scripts need bash. Pipes2-slim already uses bash as the shell, now the vanilla pipes2 does the same.